### PR TITLE
feat: :sparkles: Type: Enhancement | Title: Adding Subscription Functionality to Communities

### DIFF
--- a/app/(main)/r/[slug]/layout.tsx
+++ b/app/(main)/r/[slug]/layout.tsx
@@ -1,0 +1,124 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { format } from "date-fns";
+
+import { buttonVariants } from "@/components/ui/button";
+import { getAuthSession } from "@/lib/auth";
+import { db } from "@/lib/db";
+import SubscribeLeaveToggle from "@/components/posts/subscribe-leave-toggle";
+
+export const metadata: Metadata = {
+  title: "SpreadIt",
+  description:
+    "SpreadIt is a dynamic social news aggregation platform powered by robust backend technologies and a user-friendly interface. It employs modern web development frameworks and scalable architecture to enable seamless content submission, sharing, and voting across various formats (articles, images, videos).",
+};
+
+type SlugLayoutProps = {
+  children: React.ReactNode;
+  params: {
+    slug: string;
+  };
+};
+
+const SlugLayout = async ({ children, params: { slug } }: SlugLayoutProps) => {
+  const session = await getAuthSession();
+
+  const subSpreadIt = await db.subSpreadIt.findFirst({
+    where: { name: slug },
+    include: {
+      posts: {
+        include: {
+          author: true,
+          votes: true,
+        },
+      },
+    },
+  });
+
+  const subscription = !session?.user
+    ? undefined
+    : await db.subscription.findFirst({
+        where: {
+          subSpreadIt: {
+            name: slug,
+          },
+          user: {
+            id: session.user.id,
+          },
+        },
+      });
+
+  const isSubscribed = !!subscription;
+
+  if (!subSpreadIt) return notFound();
+
+  const memberCount = await db.subscription.count({
+    where: {
+      subSpreadIt: {
+        name: slug,
+      },
+    },
+  });
+
+  return (
+    <div className="sm:container max-w-7xl mx-auto h-full pt-12">
+      <div>
+        {/* <ToFeedButton /> */}
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-y-4 md:gap-x-4 py-6">
+          <ul className="flex flex-col col-span-2 space-y-6">{children}</ul>
+
+          {/* info sidebar */}
+          <div className="overflow-hidden h-fit rounded-lg border order-first md:order-last">
+            <div className="px-6 py-4">
+              <p className="font-semibold py-3">About r/{subSpreadIt.name}</p>
+            </div>
+            <dl className="divide-y divide-border px-6 py-4 text-sm leading-6 bg-background">
+              <div className="flex justify-between gap-x-4 py-3">
+                <dt className="text-muted-foreground">Created</dt>
+                <dd className="text-muted">
+                  <time dateTime={subSpreadIt.createdAt.toDateString()}>
+                    {format(subSpreadIt.createdAt, "d MMM, yyyy")}
+                  </time>
+                </dd>
+              </div>
+              <div className="flex justify-between gap-x-4 py-3">
+                <dt className="text-muted-foreground">Members</dt>
+                <dd className="flex items-start gap-x-2">
+                  <div className="text-muted">{memberCount}</div>
+                </dd>
+              </div>
+              {subSpreadIt.creatorId === session?.user?.id ? (
+                <div className="flex justify-between gap-x-4 py-3">
+                  <dt className="text-muted-foreground">
+                    You are the community creator
+                  </dt>
+                </div>
+              ) : null}
+
+              {subSpreadIt.creatorId !== session?.user?.id ? (
+                <SubscribeLeaveToggle
+                  isSubscribed={isSubscribed}
+                  subSpreadItId={subSpreadIt.id}
+                  subSpreadItName={subSpreadIt.name}
+                />
+              ) : null}
+              <Link
+                className={buttonVariants({
+                  variant: "primary",
+                  className: "w-full mb-6",
+                })}
+                href={`r/${slug}/submit`}
+              >
+                Create Post
+              </Link>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SlugLayout;

--- a/app/(main)/r/create/page.tsx
+++ b/app/(main)/r/create/page.tsx
@@ -112,7 +112,7 @@ const CreatePage = () => {
             onClick={() => createCommunity()}
             variant={"primary"}
           >
-            SpreadIt
+            Create Community
           </Button>
         </div>
       </div>

--- a/app/api/subspreadit/subscribe/route.ts
+++ b/app/api/subspreadit/subscribe/route.ts
@@ -1,0 +1,51 @@
+import { getAuthSession } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { SubSpreadItSubscriptionValidator } from "@/lib/validators/sub-spreadIt";
+import { z } from "zod";
+
+export async function POST(req: Request) {
+  try {
+    const session = await getAuthSession();
+
+    if (!session?.user) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const body = await req.json();
+    const { subSpreadItId } = SubSpreadItSubscriptionValidator.parse(body);
+
+    // check if user has already subscribed to subSpreadIt
+    const subscriptionExists = await db.subscription.findFirst({
+      where: {
+        subSpreadItId,
+        userId: session.user.id,
+      },
+    });
+
+    if (subscriptionExists) {
+      return new Response("You've already subscribed to this subSpreadIt", {
+        status: 400,
+      });
+    }
+
+    // create subSpreadIt and associate it with the user
+    await db.subscription.create({
+      data: {
+        subSpreadItId,
+        userId: session.user.id,
+      },
+    });
+
+    return new Response(subSpreadItId);
+  } catch (error) {
+    error;
+    if (error instanceof z.ZodError) {
+      return new Response(error.message, { status: 400 });
+    }
+
+    return new Response(
+      "Could not subscribe to subSpreadIt at this time. Please try later",
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/subspreadit/unsubscribe/route.ts
+++ b/app/api/subspreadit/unsubscribe/route.ts
@@ -1,0 +1,56 @@
+import { getAuthSession } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { SubSpreadItSubscriptionValidator } from "@/lib/validators/sub-spreadIt";
+import { z } from "zod";
+
+export async function POST(req: Request) {
+  try {
+    const session = await getAuthSession();
+
+    if (!session?.user) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const body = await req.json();
+    const { subSpreadItId } = SubSpreadItSubscriptionValidator.parse(body);
+
+    // check if user has already subscribed or not
+    const subscriptionExists = await db.subscription.findFirst({
+      where: {
+        subSpreadItId,
+        userId: session.user.id,
+      },
+    });
+
+    if (!subscriptionExists) {
+      return new Response(
+        "You've not been subscribed to this subSpreadIt, yet.",
+        {
+          status: 400,
+        }
+      );
+    }
+
+    // create subSpreadIt and associate it with the user
+    await db.subscription.delete({
+      where: {
+        userId_subSpreadItId: {
+          subSpreadItId,
+          userId: session.user.id,
+        },
+      },
+    });
+
+    return new Response(subSpreadItId);
+  } catch (error) {
+    error;
+    if (error instanceof z.ZodError) {
+      return new Response(error.message, { status: 400 });
+    }
+
+    return new Response(
+      "Could not unsubscribe from subSpreadIt at this time. Please try later",
+      { status: 500 }
+    );
+  }
+}

--- a/components/posts/subscribe-leave-toggle.tsx
+++ b/components/posts/subscribe-leave-toggle.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { startTransition } from "react";
+import { useRouter } from "next/navigation";
+import { useMutation } from "@tanstack/react-query";
+import axios, { AxiosError } from "axios";
+
+import { SubscribeToSubSpreadItPayload } from "@/lib/validators/sub-spreadIt";
+import { useCustomToasts } from "@/hooks/use-custom-toasts";
+import { useToast } from "@/hooks/use-toast";
+import { Button } from "../ui/button";
+
+type SubscribeLeaveToggleProps = {
+  isSubscribed: boolean;
+  subSpreadItId: string;
+  subSpreadItName: string;
+};
+
+const SubscribeLeaveToggle = ({
+  isSubscribed,
+  subSpreadItId,
+  subSpreadItName,
+}: SubscribeLeaveToggleProps) => {
+  const { toast } = useToast();
+  const { signInToast } = useCustomToasts();
+  const router = useRouter();
+
+  // @ts-expect-error
+  const { mutate: subscribe, isLoading: isSubLoading } = useMutation({
+    mutationFn: async () => {
+      const payload: SubscribeToSubSpreadItPayload = {
+        subSpreadItId,
+      };
+
+      const { data } = await axios.post("/api/subspreadit/subscribe", payload);
+      return data as string;
+    },
+    onError: (err) => {
+      if (err instanceof AxiosError) {
+        if (err.response?.status === 401) {
+          return signInToast();
+        }
+      }
+
+      return toast({
+        title: "There was a problem.",
+        description: "Something went wrong. Please try again.",
+        variant: "default",
+      });
+    },
+    onSuccess: () => {
+      startTransition(() => {
+        // Refresh the current route and fetch new data from the server without
+        // losing client-side browser or React state.
+        router.refresh();
+      });
+      toast({
+        title: "Subscribed!",
+        description: `You are now subscribed to r/${subSpreadItName}`,
+      });
+    },
+  });
+
+  // @ts-expect-error
+  const { mutate: unsubscribe, isLoading: isUnsubLoading } = useMutation({
+    mutationFn: async () => {
+      const payload: SubscribeToSubSpreadItPayload = {
+        subSpreadItId,
+      };
+
+      const { data } = await axios.post(
+        "/api/subspreadit/unsubscribe",
+        payload
+      );
+      return data as string;
+    },
+    onError: (err: AxiosError) => {
+      toast({
+        title: "Error",
+        description: err.response?.data as string,
+        variant: "default",
+      });
+    },
+    onSuccess: () => {
+      startTransition(() => {
+        // Refresh the current route and fetch new data from the server without
+        // losing client-side browser or React state.
+        router.refresh();
+      });
+      toast({
+        title: "Unsubscribed!",
+        description: `You are now unsubscribed from/${subSpreadItName}`,
+      });
+    },
+  });
+
+  return isSubscribed ? (
+    <Button
+      className="w-full mt-1 mb-4"
+      isLoading={isUnsubLoading}
+      onClick={() => unsubscribe()}
+    >
+      Leave community
+    </Button>
+  ) : (
+    <Button
+      className="w-full mt-1 mb-4"
+      isLoading={isSubLoading}
+      onClick={() => subscribe()}
+    >
+      Join to post
+    </Button>
+  );
+};
+
+export default SubscribeLeaveToggle;


### PR DESCRIPTION
Description: 
The changes introduce the ability for users to subscribe and unsubscribe from communities (subSpreadIt). This includes the creation of new API routes for subscribing and unsubscribing, as well as the addition of a toggle button in the community layout for users to interact with. The changes also include error handling for various scenarios such as when a user is not authenticated or already subscribed.

Main Files Walkthrough :
- app/(main)/r/create/page.tsx: The text on the button for creating a community has been changed from "SpreadIt" to "Create Community".
- app/(main)/r/[slug]/layout.tsx: A new layout file for individual community pages has been added. It includes metadata for the page, a count of members, and a check for whether the current user is subscribed to the community. It also includes a "SubscribeLeaveToggle" component for subscribing or unsubscribing from the community.
- app/api/subspreadit/subscribe/route.ts: A new API route for subscribing to a community has been added. It checks if the user is authenticated and if they are already subscribed to the community before creating a new subscription.
- app/api/subspreadit/unsubscribe/route.ts: A new API route for unsubscribing from a community has been added. It checks if the user is authenticated and if they are not already subscribed to the community before deleting the subscription.
- components/posts/subscribe-leave-toggle.tsx: A new component for subscribing or unsubscribing from a community has been added. It includes a button that toggles between "Join to post" and "Leave community" based on whether the user is currently subscribed. It also includes error handling for various scenarios.

- Users can now subscribe or unsubscribe subSpreadIts.
- Users can create posts on the subsSpreadIts that they are members or part off.